### PR TITLE
Potential fix for code scanning alert no. 38: Uncontrolled command line

### DIFF
--- a/backend/src/api/routes/pluginIde.js
+++ b/backend/src/api/routes/pluginIde.js
@@ -675,10 +675,10 @@ router.post('/:pluginName/create-pr', resolvePluginPath, async (req, res) => {
 
 
             if (branchExists) {
-                cp.execSync(`git push origin ${branch} --force`);
+                cp.execFileSync('git', ['push', 'origin', branch, '--force']);
                 console.log(`[Plugin IDE] Ветка ${branch} обновлена`);
             } else {
-                cp.execSync(`git push -u origin ${branch}`);
+                cp.execFileSync('git', ['push', '-u', 'origin', branch]);
                 console.log(`[Plugin IDE] Новая ветка ${branch} создана`);
             }
 


### PR DESCRIPTION
Potential fix for [https://github.com/blockmineJS/blockmine/security/code-scanning/38](https://github.com/blockmineJS/blockmine/security/code-scanning/38)

The proper fix is to avoid passing user-controllable string interpolation to a shell command. Replace `cp.execSync('git push -u origin ${branch}')` with a call to `cp.execFileSync`, passing the command and arguments as an array rather than as a single string. This prevents command injection by ensuring that even if `branch` contains arguments with special characters, it will be treated as a single argument, not as shell syntax.

Edit line 681 and line 678, which similarly use interpolated branch names.  
Change from:  
- `cp.execSync('git push -u origin ${branch}')`  
- `cp.execSync('git push origin ${branch} --force')`  

To:  
- `cp.execFileSync('git', ['push', '-u', 'origin', branch], ...)`  
- `cp.execFileSync('git', ['push', 'origin', branch, '--force'], ...)`  

Additionally, check for any need to adapt other similar patterns in the block.  
You will need to require the `child_process` module (already done on line 585), and ensure the proper error handling persists.

You may also want to use `{ stdio: 'inherit' }` or `{ stdio: 'pipe' }` to maintain current functionality, depending on requirements.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Replace `cp.execSync` with `cp.execFileSync` for executing git commands to mitigate uncontrolled command line risks.

### Why are these changes being made?
This change addresses code scanning alert no. 38, which indicated a potential security risk with the use of `cp.execSync`, as it can execute arbitrary code if user inputs are not properly sanitized. By switching to `cp.execFileSync`, the command and its arguments are passed separately, reducing the risk of injection and enhancing security.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->