### PR TITLE
feat: добавлена поддержка типа select для настроек плагинов

### DIFF
--- a/backend/src/ai/plugin-assistant-system-prompt.md
+++ b/backend/src/ai/plugin-assistant-system-prompt.md
@@ -482,11 +482,13 @@ bot.events.on('core:raw_message', (rawText, jsonMsg) => {
 **Формат options:**
 
 1. **Простой массив строк** - когда значение и label совпадают:
+
 ```javascript
 "options": ["easy", "normal", "hard"]
 ```
 
-2. **Массив объектов** - когда нужны разные value и label:
+1. **Массив объектов** - когда нужны разные value и label:
+
 ```javascript
 "options": [
     { "value": "ru", "label": "Русский" },
@@ -499,6 +501,7 @@ bot.events.on('core:raw_message', (rawText, jsonMsg) => {
 Сохраненное значение всегда будет строкой (например: `"normal"`, `"ru"`)
 
 **Пример использования в плагине:**
+
 ```javascript
 module.exports = (bot, { settings }) => {
     const mode = settings.mode; // "easy" | "normal" | "hard"

--- a/frontend/src/components/PluginSettingsDialog.jsx
+++ b/frontend/src/components/PluginSettingsDialog.jsx
@@ -15,6 +15,7 @@ import { apiHelper } from '@/lib/api';
 import PluginDetailInfo from './PluginDetailInfo';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { useAppStore } from '@/stores/appStore';
+import { shouldShowField } from '@/lib/pluginSettingsUtils';
 
 function JsonEditorDialog({ initialValue, onSave, onCancel }) {
     const [jsonString, setJsonString] = useState('');
@@ -205,7 +206,7 @@ function SettingField({ settingKey, config, value, onChange, readOnly }) {
             return (
                 <div className="space-y-2">
                     <Label htmlFor={id}>{config.label}</Label>
-                    <Select value={value || config.default || ''} onValueChange={readOnly ? undefined : ((newValue) => onChange(settingKey, newValue))} disabled={readOnly}>
+                    <Select value={value ?? config.default ?? ''} onValueChange={readOnly ? undefined : ((newValue) => onChange(settingKey, newValue))} disabled={readOnly}>
                         <SelectTrigger id={id}>
                             <SelectValue placeholder="Выберите значение" />
                         </SelectTrigger>
@@ -384,16 +385,6 @@ export default function PluginSettingsDialog({ bot, plugin, onOpenChange, onSave
         }
     };
 
-    // Определяем, какие поля показывать на основе условий
-    const shouldShowField = (key, config) => {
-        // Если есть поле actionsPreset, то поля enable* показываем только при custom
-        const actionsPresetValue = settings?.actionsPreset;
-        if (actionsPresetValue !== undefined && key.startsWith('enable')) {
-            return actionsPresetValue === 'custom';
-        }
-        return true;
-    };
-
     const renderSettings = () => {
         if (settings === null) return <div className="text-center p-4"><Loader2 className="h-6 w-6 animate-spin mx-auto"/></div>;
         if (Object.keys(manifestSettings).length === 0) return <p className="text-muted-foreground p-4 text-center">У этого плагина нет настроек.</p>;
@@ -407,7 +398,7 @@ export default function PluginSettingsDialog({ bot, plugin, onOpenChange, onSave
                             <AccordionContent className="pt-4 border-t space-y-4">
                                 {Object.entries(categoryConfig)
                                     .filter(([key]) => key !== 'label')
-                                    .filter(([key, config]) => shouldShowField(key, config))
+                                    .filter(([key, config]) => shouldShowField(key, settings?.actionsPreset))
                                     .map(([key, config]) => (
                                         <SettingField
                                             key={key}
@@ -428,7 +419,7 @@ export default function PluginSettingsDialog({ bot, plugin, onOpenChange, onSave
         return (
             <div className="space-y-4">
                 {Object.entries(manifestSettings)
-                    .filter(([key, config]) => shouldShowField(key, config))
+                    .filter(([key, config]) => shouldShowField(key, settings?.actionsPreset))
                     .map(([key, config]) => (
                         <SettingField
                             key={key}

--- a/frontend/src/components/PluginSettingsForm.jsx
+++ b/frontend/src/components/PluginSettingsForm.jsx
@@ -9,6 +9,7 @@ import { Edit } from 'lucide-react';
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogFooter, DialogTrigger } from "@/components/ui/dialog";
 import Editor from '@monaco-editor/react';
 import { useAppStore } from '@/stores/appStore';
+import { shouldShowField } from '@/lib/pluginSettingsUtils';
 
 function JsonEditorDialog({ initialValue, onSave, onCancel }) {
     const [jsonString, setJsonString] = useState('');
@@ -201,7 +202,7 @@ function SettingField({ settingKey, config, value, onChange }) {
             return (
                 <div className="space-y-2">
                     <Label htmlFor={id}>{config.label}</Label>
-                    <Select value={value || config.default || ''} onValueChange={(newValue) => onChange(settingKey, newValue)}>
+                    <Select value={value ?? config.default ?? ''} onValueChange={(newValue) => onChange(settingKey, newValue)}>
                         <SelectTrigger id={id}>
                             <SelectValue placeholder="Выберите значение" />
                         </SelectTrigger>
@@ -257,20 +258,10 @@ export default function PluginSettingsForm({ plugin, onSettingsChange }) {
         onSettingsChange(plugin.id, newSettings);
     };
 
-    // Определяем, какие поля показывать на основе условий
-    const shouldShowField = (key, config) => {
-        // Если есть поле actionsPreset, то поля enable* показываем только при custom
-        const actionsPresetValue = plugin.settings.actionsPreset;
-        if (actionsPresetValue !== undefined && key.startsWith('enable')) {
-            return actionsPresetValue === 'custom';
-        }
-        return true;
-    };
-
     return (
         <div className="space-y-6">
             {Object.entries(plugin.manifest.settings)
-                .filter(([key, config]) => shouldShowField(key, config))
+                .filter(([key, config]) => shouldShowField(key, plugin.settings?.actionsPreset))
                 .map(([key, config]) => (
                     <SettingField
                         key={key}

--- a/frontend/src/lib/pluginSettingsUtils.js
+++ b/frontend/src/lib/pluginSettingsUtils.js
@@ -1,0 +1,15 @@
+/**
+ * Определяет, должно ли поле настройки плагина отображаться
+ * на основе условий (например, actionsPreset)
+ *
+ * @param {string} key - Ключ поля настройки
+ * @param {any} actionsPresetValue - Значение поля actionsPreset (если есть)
+ * @returns {boolean} - Должно ли поле отображаться
+ */
+export const shouldShowField = (key, actionsPresetValue) => {
+    // Если есть поле actionsPreset, то поля enable* показываем только при custom
+    if (actionsPresetValue !== undefined && key.startsWith('enable')) {
+        return actionsPresetValue === 'custom';
+    }
+    return true;
+};


### PR DESCRIPTION
## Описание

Добавлена поддержка нового типа поля `select` для настроек плагинов, позволяющего создавать выпадающие списки с предопределенными значениями.

## Изменения

### Поддержка типа select
- ✅ Добавлен новый case 'select' в `PluginSettingsForm.jsx`
- ✅ Добавлен новый case 'select' в `PluginSettingsDialog.jsx`
- ✅ Поддержка двух форматов опций:
  - Простой массив строк: `["option1", "option2"]`
  - Массив объектов: `[{ value: "val1", label: "Label 1" }]`

### Условное отображение полей
- ✅ Реализована логика условного отображения полей настроек
- ✅ Поля с ключами `enable*` показываются только если `actionsPreset === 'custom'`
- ✅ Улучшен UX - переключатели скрываются при выборе готового пресета

### Документация
- ✅ Обновлена документация для разработчиков плагинов (`plugin-assistant-system-prompt.md`)
- ✅ Добавлены примеры использования select field
- ✅ Добавлена таблица типов настроек с новым типом

### Code Review исправления ✅
- ✅ Исправлено форматирование Markdown (пустые строки, нумерация)
- ✅ Заменён оператор `||` на `??` для значений по умолчанию
- ✅ Добавлен optional chaining `plugin.settings?.actionsPreset`
- ✅ Создана общая утилита `lib/pluginSettingsUtils.js`
- ✅ Устранено дублирование кода между компонентами

## Примеры использования

### Простой массив строк
```json
{
  "mode": {
    "type": "select",
    "label": "Режим работы",
    "options": ["easy", "normal", "hard"],
    "default": "normal"
  }
}
```

### Массив объектов с value и label
```json
{
  "language": {
    "type": "select",
    "label": "Язык",
    "options": [
      { "value": "ru", "label": "Русский" },
      { "value": "en", "label": "English" }
    ],
    "default": "ru"
  }
}
```

## Файлы изменены

- `frontend/src/components/PluginSettingsForm.jsx` - основной компонент форм
- `frontend/src/components/PluginSettingsDialog.jsx` - компонент диалога настроек
- `frontend/src/lib/pluginSettingsUtils.js` - общая утилита для условной логики
- `backend/src/ai/plugin-assistant-system-prompt.md` - документация для AI и разработчиков

## Коммиты

1. `feat: добавлена поддержка типа select для настроек плагинов` [39aba61]
2. `fix: добавлена поддержка типа select в PluginSettingsDialog` [fe6cfb3]
3. `feat: условное отображение полей настроек плагинов` [264c5cf]
4. `refactor: исправлены замечания code review` [e340fbe] ⭐ **NEW**