### PR TITLE
fix: валидация портов серверов и автоочистка невалидных записей

### DIFF
--- a/backend/src/api/routes/servers.js
+++ b/backend/src/api/routes/servers.js
@@ -39,8 +39,14 @@ router.post('/', authorize('server:create'), async (req, res) => {
         if (!name || !host || !version) {
             return res.status(400).json({ error: 'Имя, хост и версия сервера обязательны' });
         }
+
+        const portNumber = port ? parseInt(port, 10) : 25565;
+        if (isNaN(portNumber) || portNumber < 1 || portNumber > 65535) {
+            return res.status(400).json({ error: 'Порт должен быть числом от 1 до 65535 (максимум 5 цифр)' });
+        }
+
         const newServer = await prisma.server.create({
-            data: { name, host, port: port ? parseInt(port, 10) : 25565, version },
+            data: { name, host, port: portNumber, version },
         });
         res.status(201).json(newServer);
     } catch (error) {
@@ -58,7 +64,13 @@ router.put('/:id', authorize('server:create'), async (req, res) => {
         const dataToUpdate = {};
         if (name !== undefined) dataToUpdate.name = name;
         if (host !== undefined) dataToUpdate.host = host;
-        if (port !== undefined && port !== '') dataToUpdate.port = parseInt(port, 10);
+        if (port !== undefined && port !== '') {
+            const portNumber = parseInt(port, 10);
+            if (isNaN(portNumber) || portNumber < 1 || portNumber > 65535) {
+                return res.status(400).json({ error: 'Порт должен быть числом от 1 до 65535 (максимум 5 цифр)' });
+            }
+            dataToUpdate.port = portNumber;
+        }
         if (version !== undefined) dataToUpdate.version = version;
 
         Object.keys(dataToUpdate).forEach(k => { if (dataToUpdate[k] === undefined) delete dataToUpdate[k]; });


### PR DESCRIPTION
## Описание

Исправлена проблема с невалидными портами серверов, которая приводила к ошибке 
`Value does not fit in an INT column` при попытке создать сервер с портом 
больше 5 цифр (больше 65535).

## Изменения

### Валидация портов
- ✅ Добавлена валидация порта (1-65535) при создании сервера
- ✅ Добавлена валидация порта при обновлении сервера
- ✅ Понятные сообщения об ошибках для пользователя

### Автоматическая очистка
- ✅ Автоудаление серверов с невалидными портами при старте приложения
- ✅ Использован прямой SQL запрос для обхода ограничений Prisma ORM
- ✅ Проверка трех условий: длина > 5 цифр, порт > 65535, порт < 1

## Файлы изменены

- `backend/src/api/routes/servers.js` - валидация в API endpoints
- `backend/src/server.js` - автоочистка при старте

## Тестирование

- [x] База данных очищена от невалидных портов
- [x] Невозможно создать сервер с портом > 65535
- [x] Невозможно обновить сервер с портом > 65535
- [x] При старте автоматически удаляются серверы с невалидными портами

## Summary by Sourcery

Обеспечить использование допустимых диапазонов серверных портов и очистку некорректных записей о серверах при запуске.

Исправления ошибок:
- Предотвратить создание и обновление серверов с портами вне допустимого диапазона, которые ранее вызывали ошибки переполнения столбца типа INT.

Улучшения:
- Проверять порты серверов (1–65535) при создании и обновлении, выводя понятные пользователю сообщения об ошибках.
- Автоматически удалять существующие серверы с недопустимыми значениями портов во время запуска приложения с помощью прямой SQL-очистки.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce valid server port ranges and clean up invalid server records on startup.

Bug Fixes:
- Prevent creation and update of servers with ports outside the valid range that previously caused INT column overflow errors.

Enhancements:
- Validate server ports (1–65535) on create and update with user-friendly error messages.
- Automatically delete existing servers with invalid port values during application startup via a direct SQL cleanup.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Новые возможности
* Добавлена валидация номера порта при создании и обновлении сервера (допускаются только целые числа от 1 до 65535)

## Исправления ошибок
* Автоматическая очистка серверов с невалидными портами при запуске системы

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->