### PR TITLE
fix: close active connection on API key deletion

### DIFF
--- a/backend/src/api/routes/apiKeys.js
+++ b/backend/src/api/routes/apiKeys.js
@@ -163,6 +163,14 @@ router.delete('/:keyId', authorize('bot:update'), async (req, res) => {
         const botId = parseInt(req.params.botId, 10);
         const keyId = parseInt(req.params.keyId, 10);
 
+        const { getIO } = require('../../real-time/socketHandler');
+
+        const io = getIO();
+
+        io.of("/bot-api")
+            .in(`key_${keyId}`)
+            .disconnectSockets(true)
+
         const result = await prisma.botApiKey.deleteMany({
             where: { id: keyId, botId },
         });

--- a/backend/src/real-time/botApi/index.js
+++ b/backend/src/real-time/botApi/index.js
@@ -16,7 +16,7 @@ function initializeBotApiNamespace(io) {
         console.log(`[Bot API] Клиент подключился к боту ID: ${socket.botId} (ключ: ${socket.keyPrefix})`);
 
         socket.join(`bot_${socket.botId}`);
-
+        socket.join(`key_${socket.keyId}`);
 
         const isOnline = botManager.isBotRunning(socket.botId);
         socket.emit('bot:status', { online: isOnline });


### PR DESCRIPTION
## Issue
On API key deletion, established websocket connections continue to have access

### Steps to reproduce
1. Create api key in `websocket` tab
2. Connect using documentation
3. Remove key

### Changes
- Terminate active websocket connections associated with the deleted API key

## Summary by Sourcery

Исправления ошибок:
- Закрывать активные WebSocket‑подключения Bot API, которые продолжают использовать ключ API после его удаления, связывая сокеты с этим ключом и принудительно разрывая такие соединения.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Close active bot API websocket connections that are still using an API key after it has been deleted by associating sockets with the key and force-disconnecting them.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Примечания к выпуску

* **Исправления ошибок**
  * Улучшена очистка соединений при удалении API-ключей. Система теперь корректно разрывает активные соединения, связанные с удаляемым ключом, обеспечивая более надежное управление состоянием в реальном времени.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->